### PR TITLE
CC-8 # Change project name from CDN to Client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ By contributing you agree to the [LICENSE](LICENSE) of this repository.
 
 - Pull / Merge Request descriptions should include a change summary that matches the [Keep a CHANGELOG](http://keepachangelog.com/) format
 
-- this project uses the [GitHub Flow](https://guides.github.com/introduction/flow/) branching scheme, so changes should target the "master" branch
+- this project uses the [Git Flow](http://nvie.com/posts/a-successful-git-branching-model/) branching scheme, so changes should target the "develop" branch
+
 
 - feel free to submit un-squashed commits provided tests pass for all commits
 

--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of bmp-cdn-cli nor the names of its
+* Neither the name of bmp-client-cli nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# bmp-cdn-cli
-CLI utility for BlinkMobile's Mobility Platform CDN
+# Blink Client Uploader
+
+CLI utility for BlinkMobile's Mobility Platform CDN.

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,5 +1,5 @@
 module.exports = `
-  Usage: bm cdn <command>
+  Usage: bm client <command>
 
   Where command is one of:
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@blinkmobile/cdn-cli",
+  "name": "@blinkmobile/client-cli",
   "version": "0.0.1",
   "description": "CLI utility for BlinkMobile's Mobility Platform CDN",
   "main": "index.js",
   "bin": {
-    "blinkm-cli": "./bin/index.js"
+    "blinkm-client": "./bin/index.js"
   },
   "engines": {
     "node": ">=4.0.0",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/blinkmobile/bmp-cdn-cli.git"
+    "url": "git@github.com:blinkmobile/blink-client-cli.git"
   },
   "keywords": [
     "BlinkMobile",
@@ -33,9 +33,9 @@
   "author": "Simon Dobie",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/blinkmobile/bmp-cdn-cli/issues"
+    "url": "https://github.com/blinkmobile/blink-client-cli/issues"
   },
-  "homepage": "https://github.com/blinkmobile/bmp-cdn-cli#readme",
+  "homepage": "https://github.com/blinkmobile/blink-client-cli#readme",
   "devDependencies": {
     "ava": "^0.12.0",
     "eslint": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:blinkmobile/blink-client-cli.git"
+    "url": "git@github.com:blinkmobile/client-cli.git"
   },
   "keywords": [
     "BlinkMobile",
@@ -33,9 +33,9 @@
   "author": "Simon Dobie",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/blinkmobile/blink-client-cli/issues"
+    "url": "https://github.com/blinkmobile/client-cli/issues"
   },
-  "homepage": "https://github.com/blinkmobile/blink-client-cli#readme",
+  "homepage": "https://github.com/blinkmobile/client-cli#readme",
   "devDependencies": {
     "ava": "^0.12.0",
     "eslint": "^1.10.3",


### PR DESCRIPTION
- update git repo names
- update anywhere any references to 'cdn' are used to use 'client'

Note: the git remote has been updated

`git remote set-url origin git@github.com:blinkmobile/blink-client-cli.git`