### PR TITLE
CC-11 # accurate ContentType detection; `deploy --no-skip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,23 @@ See [usage.md](https://github.com/blinkmobile/client-cli/blob/develop/docs/usage
 npm install -g @blinkmobile/cli @blinkmobile/client-cli
 ```
 
-## Scope
+## Usage
 
-`bm client scope` => To see what the current scope is set to
-`bm client scope <your bucket name>` => To set the scope to the provided bucket name
+```
+blinkm client --help
 
-## Deploying
-`bm client deploy <path to files>` => Upload the files in `<path to files>` to the specified scope
+# or, shorter
+bm client --help
+```
+
+```
+Initial settings:
+    scope                 => outputs the current scope
+    scope <S3Bucket>      => sets the bucket
+      --region <S3Region> => optionally sets the region
+
+Deploying client side code:
+    deploy <path>         => uploads files in <path> to the scoped bucket
+      --skip              => bypass unchanged files (default)
+      --no-skip           => upload all files, including unchanged
+```

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 'use strict';
 
 // foreign modules
@@ -16,7 +16,10 @@ const cli = meow({
   help,
   version: true
 }, {
-  boolean: [ 'prune' ],
+  boolean: [ 'prune', 'skip' ],
+  default: {
+    skip: true
+  },
   string: ['bucket', 'region']
 });
 

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -18,7 +18,8 @@ module.exports = function (input, flags, options) {
     .then((s3) => {
       const task = upload({
         cwd: sourceDir,
-        s3
+        s3,
+        skip: flags.skip
       });
       task.on('skipped', (fileName) => {
         clearTimeout(timer);

--- a/lib/help.js
+++ b/lib/help.js
@@ -6,10 +6,12 @@ module.exports = `
   scope, deploy
 
 Initial settings:
-    scope              => outputs the current scope
-    scope <s3 bucket name>  => sets the bucket
-    scope --bucket <s3 bucket name> [--region <s3 region>] => sets the bucket and optionally the region
+    scope                 => outputs the current scope
+    scope <S3Bucket>      => sets the bucket
+      --region <S3Region> => optionally sets the region
 
 Deploying client side code:
-    deploy <path>      => uploads any modified files in <path> to the bucket set via the scope command
+    deploy <path>         => uploads files in <path> to the scoped bucket
+      --skip              => bypass unchanged files (default)
+      --no-skip           => upload all files, including unchanged
 `;

--- a/lib/s3-bucket-params.js
+++ b/lib/s3-bucket-params.js
@@ -18,7 +18,7 @@ function toS3 (cfg) {
 
 function read () {
   return configHelper.read()
-    .then(cfg => (cfg.cdn.objectParams ? toS3(cfg) : false) || write(defaults).then(cfg => toS3(cfg)))
+    .then((cfg) => (cfg.cdn.objectParams ? toS3(cfg) : false) || write(defaults).then((cfg) => toS3(cfg)))
     .catch(() => {
       console.log('No scope has been set. Please set the scope and try again');
       process.exit(1);
@@ -26,7 +26,7 @@ function read () {
 }
 
 function write (options) {
-  return configHelper.write(config => objectMerge(config, {cdn: {objectParams: options}}));
+  return configHelper.write((config) => objectMerge(config, {cdn: {objectParams: options}}));
 }
 
 module.exports = {read};

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -6,7 +6,7 @@ const configHelper = require('./utils/config-helper');
 
 function read () {
   return configHelper.read()
-    .then(cfg => cfg.cdn ? cfg.cdn : {});
+    .then((cfg) => cfg.cdn ? cfg.cdn : {});
 }
 
 function write (options) {
@@ -15,7 +15,7 @@ function write (options) {
   }
 
   let values = {cdn: {scope: options.scope, region: options.region}};
-  return configHelper.write(config => objectMerge(config, values));
+  return configHelper.write((config) => objectMerge(config, values));
 }
 
 function show () {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
   "access": "public",
   "homepage": "https://github.com/blinkmobile/client-cli#readme",
   "devDependencies": {
-    "ava": "^0.12.0",
-    "eslint": "^1.10.3",
-    "eslint-config-semistandard": "5.0.0",
-    "eslint-config-standard": "^4.4.0",
+    "ava": "^0.13.0",
+    "eslint": "^2.6.0",
+    "eslint-config-semistandard": "^6.0.1",
+    "eslint-config-standard": "^5.1.0",
+    "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.1",
     "mockery": "^1.4.0",
     "npm-run-all": "^1.5.1",
@@ -49,7 +50,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@blinkmobile/aws-s3": "1.1.1",
+    "@blinkmobile/aws-s3": "1.2.0",
     "@blinkmobile/blinkmrc": "^1.1.0",
     "aws-sdk": "^2.2.36",
     "elegant-spinner": "1.0.1",

--- a/test/file-read-perf.js
+++ b/test/file-read-perf.js
@@ -26,7 +26,7 @@ const s3BucketFactoryMock = () => Promise.resolve({
   upload (options, callback) { callback(null); }
 });
 
-const makeArray = num => {
+const makeArray = (num) => {
   let arr = [];
   for (let i = 0; i < num; ++i) {
     arr.push(i);
@@ -35,7 +35,7 @@ const makeArray = num => {
   return arr;
 };
 
-const createFile = dir => id => {
+const createFile = (dir) => (id) => {
   const filePath = path.join(dir, `${id}.js`);
   return pWriteFile(filePath, fileData);
 };
@@ -55,20 +55,20 @@ mockery.registerAllowables([
 test.after(() => mockery.disable());
 
 function makeTest (timerLabel, numFiles) {
-  return t => {
+  return (t) => {
     const deploy = require('../commands/deploy');
-    const upload = dir => {
+    const upload = (dir) => {
       console.time(timerLabel);
       deploy([dir]);
     };
 
     let tempPath;
-    return pMkdir('temp' + numFiles).then(dirPath => {
+    return pMkdir('temp' + numFiles).then((dirPath) => {
       let count = makeArray(100);
       tempPath = dirPath;
       return Promise.all(count.map(createFile(tempPath)));
-    }).then(results => upload(tempPath))
-      .then(result => console.timeEnd(timerLabel));
+    }).then((results) => upload(tempPath))
+      .then((result) => console.timeEnd(timerLabel));
   };
 }
 

--- a/test/file-read-perf.js
+++ b/test/file-read-perf.js
@@ -59,7 +59,7 @@ function makeTest (timerLabel, numFiles) {
     const deploy = require('../commands/deploy');
     const upload = (dir) => {
       console.time(timerLabel);
-      deploy([dir]);
+      deploy([dir], {});
     };
 
     let tempPath;

--- a/test/s3-bucket-factory.js
+++ b/test/s3-bucket-factory.js
@@ -17,7 +17,7 @@ test.afterEach(() => {
   mockery.disable();
 });
 
-test('it should have the bucket name pre-configured', t => {
+test('it should have the bucket name pre-configured', (t) => {
   const params = {
     region: 'region',
     params: {
@@ -35,5 +35,5 @@ test('it should have the bucket name pre-configured', t => {
   mockery.registerMock(s3BucketParamsModule, s3BucketParamsMock);
 
   const s3Factory = require('../lib/s3-bucket-factory.js');
-  return s3Factory().then(s3 => t.ok(s3.config.params.Bucket));
+  return s3Factory().then((s3) => t.ok(s3.config.params.Bucket));
 });

--- a/test/s3-bucket-params.js
+++ b/test/s3-bucket-params.js
@@ -18,7 +18,7 @@ test.afterEach(() => {
   mockery.disable();
 });
 
-test.serial('it should return the stored params', t => {
+test.serial('it should return the stored params', (t) => {
   const config = {
     cdn: {
       scope: 'a',
@@ -50,10 +50,10 @@ test.serial('it should return the stored params', t => {
 
   t.plan(1);
 
-  return scope.read().then(s => t.same(expectedConfig, s));
+  return scope.read().then((s) => t.same(expectedConfig, s));
 });
 
-test.serial('it should return the default params and call write()', t => {
+test.serial('it should return the default params and call write()', (t) => {
   const config = {
     cdn: {
       scope: 'a',
@@ -73,5 +73,5 @@ test.serial('it should return the default params and call write()', t => {
 
   const scope = require(s3BucketParamsModule);
 
-  return scope.read().then(s => t.same(config.objectParams, s.objectParams));
+  return scope.read().then((s) => t.same(config.objectParams, s.objectParams));
 });

--- a/test/scope.js
+++ b/test/scope.js
@@ -18,7 +18,7 @@ test.afterEach(() => {
   mockery.disable();
 });
 
-test.serial('it should return the currently set scope', t => {
+test.serial('it should return the currently set scope', (t) => {
   const expectedScope = 'a';
   const configHelperMock = {
     read: () => Promise.resolve({cdn: {scope: expectedScope}})
@@ -28,10 +28,10 @@ test.serial('it should return the currently set scope', t => {
 
   const scope = require(scopeModule);
 
-  return scope.read().then(s => t.same(s.scope, expectedScope));
+  return scope.read().then((s) => t.same(s.scope, expectedScope));
 });
 
-test.serial('it should handle an unitinitalised config file', t => {
+test.serial('it should handle an unitinitalised config file', (t) => {
   const expectedScope = undefined;
   const configHelperMock = {
     read: () => Promise.resolve({})
@@ -40,12 +40,12 @@ test.serial('it should handle an unitinitalised config file', t => {
   mockery.registerMock(configHelperModule, configHelperMock);
 
   const scope = require(scopeModule);
-  return scope.read().then(s => t.same(s.scope, expectedScope));
+  return scope.read().then((s) => t.same(s.scope, expectedScope));
 });
 
-test.serial('it should reject if no scope is set', t => {
+test.serial('it should reject if no scope is set', (t) => {
   const configHelperMock = {
-    write: fn => Promise.reject({})
+    write: (fn) => Promise.reject({})
   };
 
   mockery.registerMock(configHelperModule, configHelperMock);
@@ -55,7 +55,7 @@ test.serial('it should reject if no scope is set', t => {
   t.throws(p, 'Options.scope was not defined.');
 });
 
-test.serial('it should merge new scope with the current config', t => {
+test.serial('it should merge new scope with the current config', (t) => {
   const originalConfig = {
     bmp: {
       scope: 'blah'
@@ -67,13 +67,13 @@ test.serial('it should merge new scope with the current config', t => {
   };
 
   const configHelperMock = {
-    write: fn => Promise.resolve(fn(originalConfig))
+    write: (fn) => Promise.resolve(fn(originalConfig))
   };
 
   mockery.registerMock(configHelperModule, configHelperMock);
 
   const scope = require(scopeModule);
-  scope.write({scope: 'c'}).then(config => {
+  scope.write({scope: 'c'}).then((config) => {
     t.notSame(config.cdn.scope, 'old');
     t.same(config.cdn.scope, 'c');
     t.same(config.cdn.extra, 'existing');


### PR DESCRIPTION
### Added

- CC-11: `deploy --skip` (default) and `deploy --no-skip` options (#13, @jokeyrhyme)


### Changed

- CC-11: update to [blinkmobile/aws-s3.js 1.2.0](https://github.com/blinkmobile/aws-s3.js/releases/tag/1.2.0) (#13, @jokeyrhyme)

- made documentation a bit more like [blinkmobile/bmp-cli](https://github.com/blinkmobile/bmp-cli), which means CLI `--help` and README.md are synchronised via copy-paste (simpler than 2 versions)

### Code Review Notes

- you may also want to review upstream: https://github.com/blinkmobile/aws-s3.js/pull/1