### PR TITLE
CC-37 # Allow sub directory to be deployed from project root directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - '6'
-  - '7'
+  - '8'
 sudo: false
 env:
   global:
@@ -14,5 +14,4 @@ addons:
       - g++-4.8
 install:
   - npm install --global npm
-  - npm install --global yarn
   - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Unreleased
 
+### Changed
+
+-   CC-37: CI node version from 6 and 7 to 6 and 8
 
 ## 1.0.0 - 2017-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 -   CC-37: `environment` parameter when assuming AWS role
+-   CC-37: `bm client deploy <path>` parameter to allow deploying files in a sub directory relative to the current working directory or `--cwd` flag if specified
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Added
+
+-   CC-37: `environment` parameter when assuming AWS role
+
 ### Changed
 
 -   CC-37: CI node version from 6 and 7 to 6 and 8

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Client Side code deployment [![npm](https://img.shields.io/npm/v/@blinkmobile/client-cli.svg?maxAge=2592000)](https://www.npmjs.com/package/@blinkmobile/client-cli) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/blinkmobile/client-cli?branch=master&svg=true)](https://ci.appveyor.com/project/blinkmobile/client-cli) [![Travis CI Status](https://travis-ci.org/blinkmobile/client-cli.svg?branch=master)](https://travis-ci.org/blinkmobile/client-cli) [![Greenkeeper badge](https://badges.greenkeeper.io/blinkmobile/client-cli.svg)](https://greenkeeper.io/)
+# blinkmobile / client-cli  [![npm](https://img.shields.io/npm/v/@blinkmobile/client-cli.svg?maxAge=2592000)](https://www.npmjs.com/package/@blinkmobile/client-cli) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/blinkmobile/client-cli?branch=master&svg=true)](https://ci.appveyor.com/project/blinkmobile/client-cli) [![Travis CI Status](https://travis-ci.org/blinkmobile/client-cli.svg?branch=master)](https://travis-ci.org/blinkmobile/client-cli) [![Greenkeeper badge](https://badges.greenkeeper.io/blinkmobile/client-cli.svg)](https://greenkeeper.io/)
 
-This tool is for deploying client side code for web apps to the Blink Mobile CDN.
-
-See [Usage](./docs/usage.md) for detailed usage instructions.
+CLI to deploy client-side web applications with BlinkMobile.
 
 ## Installation
 
@@ -10,17 +8,26 @@ See [Usage](./docs/usage.md) for detailed usage instructions.
 npm install -g @blinkmobile/cli @blinkmobile/identity-cli @blinkmobile/client-cli
 ```
 
+## Documentation
+
+See the [Documentation](./docs/README.md) directory for more details.
+
 ## Usage
 
 ```sh
 blinkm client --help
 
 # or, shorter
-
 bm client --help
 ```
 
-```
+```sh
+Usage: blinkm client <command>
+
+Where command is one of:
+
+  scope, deploy
+
 Initial settings:
     scope                 => outputs the current scope
     scope <S3Bucket>      => sets the bucket
@@ -35,12 +42,13 @@ Deploying client side code:
   https://github.com/blinkmobile/identity-cli#usage
 
     deploy                => uploads files in the current working directory to the scoped bucket
+      <path>              => uploads files in <path> (relative to the --cwd flag) to the scoped bucket
       --env <environment> => optionally sets the environment to deploy to, defaults to 'dev'
       --force             => deploy without confirmation
       --skip              => bypass unchanged files (default)
       --no-skip           => upload all files, including unchanged
       --prune             => remove files that do not exist locally from the server
-      --cwd <path>        => uploads files in the <path> to the scoped bucket
+      --cwd <path>        => specify the directory containing .blinkmrc.json file (defaults to '.')
       --debug             => output debug information
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,11 @@ build: 'off'
 environment:
   matrix:
     - nodejs_version: '6'
-    - nodejs_version: '7'
+    - nodejs_version: '8'
 install:
   - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install --global npm-windows-upgrade
   - npm-windows-upgrade --no-spinner --npm-version latest
-  - npm install --global yarn
   - npm install
 test_script:
   - node --version

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict'
 
+const path = require('path')
+
 const ora = require('ora')
 const chalk = require('chalk')
 const upload = require('@blinkmobile/aws-s3').upload
@@ -43,7 +45,8 @@ module.exports = function (
                 s3,
                 skip: flags.skip,
                 prune: flags.prune,
-                cwd: flags.cwd,
+                // Allow deployment of files in a sub directory to the current working directory
+                cwd: path.join(flags.cwd, (input[0] || '.')),
                 bucketPathPrefix: flags.env
               }
 

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -37,7 +37,7 @@ module.exports = function (
 
           const spinner = ora({spinner: 'dots', text: 'Uploading to CDN'})
 
-          return s3Factory(bucketDetails)
+          return s3Factory(bucketDetails, flags.env)
             .then((s3) => {
               const uploadParams = {
                 s3,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# blinkmobile / client-cli
+
+## Documentation
+
+1.  [Usage](./usage.md)
+
+## Breaking Changes
+
+-   [Migrating to `v1.x.x`](./migrate-to-v1.x.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,17 +1,22 @@
-# Client Side code deployment
+# blinkmobile / client-cli
+
+# Client Side Code Deployment
 
 This tool is for deploying client side code for web apps to the Blink Mobile CDN.
 
-## Setting scope
+## Setting Scope
 
-`blinkm client scope <your bucket name>`
+```sh
+blinkm client scope <your bucket name>
+```
 
 `<your bucket name>` is supplied by Blink Mobile
 
-
 ## Scope Information
 
-`blinkm client scope`
+```sh
+blinkm client scope
+```
 
 Will tell you what your bucket name and region are currently set to.
 
@@ -20,7 +25,9 @@ Will tell you what your bucket name and region are currently set to.
 The deploy command requires a login to BlinkMobile before use.
 For help on the login and logout commands please see: [Identity CLI Usage](https://github.com/blinkmobile/identity-cli#usage)
 
-`blinkm client deploy --env <environment> --cwd <path-to-files>`
+```sh
+blinkm client deploy <path-to-files> --env <environment> --cwd <path-to-project>`
+```
 
 When uploading, the specified path will become the root folder in the CDN:
 
@@ -29,36 +36,37 @@ When uploading, the specified path will become the root folder in the CDN:
 Running:
 
 ```
-blinkm client deploy --cwd www
+blinkm client deploy www
 ```
 
 on a directory with the following:
 
 ```
-www/
-   + index.html
-   + js/
-       + app.js
-   + img/
-       + logo.png
-       + cta.jpg
-   + css/
-       + layout.css
-       + bootstrap.css
+|-- .blinkmrc.json
+|-- www
+|   |-- index.html
+|   |-- js
+|   |   |-- app.js
+|   |-- img
+|   |   |-- logo.png
+|   |   |-- cta.jpg
+|   |-- css
+|   |   |-- layout.css
+|   |   |-- bootstrap.css
 ```
 
-will deploy the following folder structure on the cdn:
+will deploy the following folder structure on the CDN:
 
 ```
-index.html
-js/
-  + app.js
-img/
-  + logo.png
-  + cta.jpg
-css/
-  + layout.css
-  + bootstrap.css
+|-- index.html
+|-- js
+|   |-- app.js
+|-- img
+|   |-- logo.png
+|   |-- cta.jpg
+|-- css
+|   |-- layout.css
+|   |-- bootstrap.css
 ```
 
 
@@ -66,4 +74,6 @@ css/
 
 Remove the files from your local folder, then deploy using `--prune`:
 
-`bm client deploy --env <environment> --cwd <path-to-files> --prune`
+```sh
+bm client deploy <path-to-files> --env <environment> --cwd <path-to-project> --prune
+```

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,7 +1,7 @@
 module.exports = `
-  Usage: bm client <command>
+Usage: blinkm client <command>
 
-  Where command is one of:
+Where command is one of:
 
   scope, deploy
 
@@ -19,11 +19,12 @@ Deploying client side code:
   https://github.com/blinkmobile/identity-cli#usage
 
     deploy                => uploads files in the current working directory to the scoped bucket
+      <path>              => uploads files in <path> (relative to the --cwd flag) to the scoped bucket
       --env <environment> => optionally sets the environment to deploy to, defaults to 'dev'
       --force             => deploy without confirmation
       --skip              => bypass unchanged files (default)
       --no-skip           => upload all files, including unchanged
       --prune             => remove files that do not exist locally from the server
-      --cwd <path>        => uploads files in the <path> to the scoped bucket
+      --cwd <path>        => specify the directory containing .blinkmrc.json file (defaults to '.')
       --debug             => output debug information
 `

--- a/lib/s3-bucket-factory.js
+++ b/lib/s3-bucket-factory.js
@@ -15,12 +15,14 @@ const BlinkMobileIdentity = require('@blinkmobile/bm-identity')
 const blinkMobileIdentity = new BlinkMobileIdentity(pkg.name)
 
 function s3Factory (
- bucketDetails /* : Object */
+ bucketDetails /* : Object */,
+ env /* : string */
 ) /* : Promise<Object> */ {
   const spinner = ora({spinner: 'dots', text: 'Authenticating...'}).start()
   return blinkMobileIdentity.assumeAWSRole({
     bmProject: bucketDetails.params.Bucket,
-    command: 'deploy'
+    command: 'deploy',
+    environment: env
   })
     .then((credentials) => {
       spinner.succeed('Authentication complete!')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blinkmobile/client-cli",
-  "description": "CLI utility for BlinkMobile's Mobility Platform CDN",
+  "description": "CLI to deploy client-side web applications with BlinkMobile",
   "version": "1.0.0",
   "author": "Blink Mobile",
   "bin": {

--- a/test/s3-bucket-factory.js
+++ b/test/s3-bucket-factory.js
@@ -35,7 +35,7 @@ test.serial('it should have the bucket name pre-configured', (t) => {
   mockery.registerMock(identityModule, bmIdentityMock)
 
   const s3Factory = require('../lib/s3-bucket-factory.js')
-  return s3Factory(params).then((s3) => t.truthy(s3.config.params.Bucket))
+  return s3Factory(params, 'dev').then((s3) => t.truthy(s3.config.params.Bucket))
 })
 
 test.serial('it should reject and stop the spinner if authentication fails', (t) => {
@@ -55,5 +55,5 @@ test.serial('it should reject and stop the spinner if authentication fails', (t)
   mockery.registerMock(identityModule, bmIdentityMock)
 
   const s3Factory = require('../lib/s3-bucket-factory.js')
-  return t.throws(s3Factory(params), 'test error')
+  return t.throws(s3Factory(params, 'dev'), 'test error')
 })


### PR DESCRIPTION

### Added

-   CC-37: `environment` parameter when assuming AWS role
-   CC-37: `bm client deploy <path>` parameter to allow deploying files in a sub directory relative to the current working directory or `--cwd` flag if specified

### Changed

-   CC-37: CI node version from 6 and 7 to 6 and 8
